### PR TITLE
Bitbucket Lowercases repositories

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ module.exports = function () {
 
     function postBitbucketCommitStatus(build, postStatusCallback) {
         var bitbucket_state = 'FAILED',
-            bitbucket_url = 'https://' + BITBUCKET_USERNAME + ':' + BITBUCKET_API_KEY + '@api.bitbucket.org/2.0/repositories/' + build.project_name + '/commit/' + build.commit_id + '/statuses/build';
+            bitbucket_url = 'https://' + BITBUCKET_USERNAME + ':' + BITBUCKET_API_KEY + '@api.bitbucket.org/2.0/repositories/' + build.project_name.toLowerCase() + '/commit/' + build.commit_id + '/statuses/build';
 
         switch (build.status) {
         case 'waiting':


### PR DESCRIPTION
Codeship pulls the repository's project name which could have upper case letters. However, bitbucket's API uses the lowercase version of the project name causing the repository to not be found.
